### PR TITLE
Implement minimal quiz web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+quiz.db

--- a/init_db.py
+++ b/init_db.py
@@ -1,0 +1,57 @@
+import sqlite3
+from datetime import datetime
+
+# Coeficientes de puntaje segun numero de intento
+COEFFICIENTS = [1.0, 0.7, 0.4, 0.1, 0]
+
+# Preguntas de ejemplo con sus opciones
+QUESTION_OPTIONS = {
+    1: ["Par\u00eds", "Londres", "Roma", "Berl\u00edn"],
+    2: ["3", "4", "5", "6"],
+}
+
+QUESTIONS = [
+    (1, "\u00bfCapital de Francia?", 0),
+    (2, "\u00bf2+2?", 1),
+]
+
+USERS = [
+    (1, "Ana", 1),
+    (2, "Luis", 1),
+    (3, "Clara", 2),
+]
+
+GROUPS = [
+    (1, "Grupo A"),
+    (2, "Grupo B"),
+]
+
+def main():
+    conn = sqlite3.connect("quiz.db")
+    c = conn.cursor()
+
+    c.execute('CREATE TABLE IF NOT EXISTS "Group" (id INTEGER PRIMARY KEY, name TEXT)')
+    c.execute('CREATE TABLE IF NOT EXISTS "User" (id INTEGER PRIMARY KEY, name TEXT, group_id INTEGER)')
+    c.execute("""CREATE TABLE IF NOT EXISTS Question (
+        id INTEGER PRIMARY KEY,
+        text TEXT,
+        correct_option INTEGER
+    )""")
+    c.execute("""CREATE TABLE IF NOT EXISTS Attempt (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER,
+        question_id INTEGER,
+        option INTEGER,
+        is_correct INTEGER,
+        created_at TEXT
+    )""")
+
+    c.executemany('INSERT INTO "Group"(id,name) VALUES (?,?)', GROUPS)
+    c.executemany('INSERT INTO "User"(id,name,group_id) VALUES (?,?,?)', USERS)
+    c.executemany("INSERT INTO Question(id,text,correct_option) VALUES (?,?,?)", QUESTIONS)
+    conn.commit()
+    conn.close()
+    print("Base de datos inicializada")
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,169 @@
+"""Aplicacion principal del quiz con FastAPI."""
+import json
+import sqlite3
+import asyncio
+from datetime import datetime
+from typing import Dict, List
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, FileResponse
+from fastapi.staticfiles import StaticFiles
+from sse_starlette.sse import EventSourceResponse
+
+from questions_data import QUESTION_OPTIONS
+
+# TODO: implementar autenticacion real con JWT
+USER_ID = 1
+
+COEFFICIENTS = [1.0, 0.7, 0.4, 0.1, 0]
+MAX_ATTEMPTS = 4
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:8000"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+# Diccionario de listeners para SSE por grupo
+listeners: Dict[int, List[asyncio.Queue]] = {}
+
+def get_db():
+    conn = sqlite3.connect("quiz.db", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def compute_scoreboard(conn: sqlite3.Connection, group_id: int):
+    """Calcula el puntaje total por usuario en el grupo."""
+    cur = conn.cursor()
+    cur.execute('SELECT id, name FROM "User" WHERE group_id=?', (group_id,))
+    users = cur.fetchall()
+    scoreboard = []
+    for u in users:
+        total = 0
+        cur.execute(
+            "SELECT question_id, option, is_correct, created_at FROM Attempt WHERE user_id=? ORDER BY question_id, created_at",
+            (u["id"],),
+        )
+        by_question: Dict[int, List[sqlite3.Row]] = {}
+        for row in cur.fetchall():
+            by_question.setdefault(row["question_id"], []).append(row)
+        for q_attempts in by_question.values():
+            for idx, att in enumerate(q_attempts):
+                if att["is_correct"]:
+                    coef = COEFFICIENTS[idx]
+                    total += int(100 * coef)
+                    break
+        scoreboard.append({"user": u["name"], "points": total})
+    return scoreboard
+
+
+async def broadcast_scoreboard(group_id: int):
+    """Envia la tabla de puntajes a todos los listeners del grupo."""
+    conn = get_db()
+    scoreboard = compute_scoreboard(conn, group_id)
+    conn.close()
+    data = json.dumps(scoreboard)
+    queues = listeners.get(group_id, [])
+    for q in queues:
+        await q.put(data)
+
+
+@app.get("/questions/{question_id}")
+async def get_question(question_id: int):
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute("SELECT id, text, correct_option FROM Question WHERE id=?", (question_id,))
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        raise HTTPException(status_code=404, detail="Pregunta no encontrada")
+    options = QUESTION_OPTIONS.get(question_id, [])
+    return {"id": row["id"], "text": row["text"], "options": options}
+
+
+@app.post("/attempts")
+async def attempt(request: Request):
+    data = await request.json()
+    user_id = data.get("user_id", USER_ID)
+    question_id = data.get("question_id")
+    option = data.get("option")
+    if question_id is None or option is None:
+        raise HTTPException(status_code=400, detail="Datos incompletos")
+
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute("SELECT correct_option FROM Question WHERE id=?", (question_id,))
+    q = cur.fetchone()
+    if not q:
+        conn.close()
+        raise HTTPException(status_code=404, detail="Pregunta no encontrada")
+
+    cur.execute(
+        "SELECT COUNT(*) FROM Attempt WHERE user_id=? AND question_id=?",
+        (user_id, question_id),
+    )
+    prev_attempts = cur.fetchone()[0]
+    if prev_attempts >= MAX_ATTEMPTS:
+        conn.close()
+        raise HTTPException(status_code=400, detail="Maximo de intentos alcanzado")
+
+    correct = option == q["correct_option"]
+    coef = COEFFICIENTS[prev_attempts]
+    gained_points = int(100 * coef) if correct else 0
+    cur.execute(
+        """INSERT INTO Attempt(user_id, question_id, option, is_correct, created_at)
+           VALUES (?,?,?,?,?)""",
+        (user_id, question_id, option, int(correct), datetime.utcnow().isoformat()),
+    )
+    conn.commit()
+
+    # determinar grupo del usuario para notificar
+    cur.execute('SELECT group_id FROM "User" WHERE id=?', (user_id,))
+    user_row = cur.fetchone()
+    group_id = user_row["group_id"] if user_row else None
+    conn.close()
+
+    if group_id:
+        await broadcast_scoreboard(group_id)
+
+    attempts_left = MAX_ATTEMPTS - prev_attempts - 1
+    return JSONResponse(
+        {
+            "correct": correct,
+            "gained_points": gained_points,
+            "attempts_left": attempts_left,
+            "option": option,
+        }
+    )
+
+
+@app.get("/events/group/{group_id}")
+async def scoreboard_events(group_id: int):
+    """Endpoint SSE para enviar la tabla de puntajes del grupo."""
+    queue: asyncio.Queue = asyncio.Queue()
+    listeners.setdefault(group_id, []).append(queue)
+
+    async def event_generator():
+        try:
+            await broadcast_scoreboard(group_id)
+            while True:
+                data = await queue.get()
+                yield {"event": "scoreboard", "data": data}
+        finally:
+            listeners[group_id].remove(queue)
+
+    return EventSourceResponse(event_generator())
+
+
+# Ruta principal para SPA
+@app.get("/")
+async def root():
+    """Devuelve la pagina principal de la SPA."""
+    return FileResponse("static/index.html")

--- a/questions_data.py
+++ b/questions_data.py
@@ -1,0 +1,5 @@
+# Opciones de cada pregunta para esta version inicial
+QUESTION_OPTIONS = {
+    1: ["Par\u00eds", "Londres", "Roma", "Berl\u00edn"],
+    2: ["3", "4", "5", "6"],
+}

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="es" x-data="quizApp()" x-init="init()">
+<head>
+    <meta charset="UTF-8">
+    <title>Quiz</title>
+    <script src="https://unpkg.com/htmx.org@1.9.6"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.6/dist/ext/json-enc.js"></script>
+    <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+</head>
+<body>
+    <div id="question">
+        <h2 x-text="question.text"></h2>
+        <div>
+            <template x-for="(opt, idx) in question.options" :key="idx">
+                <button
+                    :id="'btn'+idx"
+                    class="option"
+                    hx-post="/attempts"
+                    hx-ext="json-enc"
+                    :hx-vals="JSON.stringify({user_id: 1, question_id: question.id, option: idx})"
+                    hx-swap="none"
+                    @click.prevent="selected=idx"
+                    :disabled="disabled[idx]"
+                    x-text="opt">
+                </button>
+            </template>
+        </div>
+    </div>
+
+    <div id="modal" x-show="modal" style="display:none; border:1px solid #000; padding:1em;">
+        <span x-text="modal"></span>
+        <button @click="modal='';">Cerrar</button>
+    </div>
+
+    <h3>Scoreboard</h3>
+    <table>
+        <thead><tr><th>Usuario</th><th>Puntos</th></tr></thead>
+        <tbody id="scoreboard"></tbody>
+    </table>
+
+    <script src="/static/js/app.js"></script>
+</body>
+</html>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,41 @@
+function quizApp() {
+    return {
+        question: {id: 1, text: '', options: []},
+        modal: '',
+        disabled: [false, false, false, false],
+        selected: null,
+        init() {
+            fetch('/questions/1')
+                .then(r => r.json())
+                .then(q => { this.question = q; });
+            this.connectSSE();
+            document.body.addEventListener('htmx:afterRequest', (e) => this.handleAttempt(e));
+        },
+        connectSSE() {
+            const evt = new EventSource('/events/group/1');
+            evt.onmessage = (ev) => {
+                const data = JSON.parse(ev.data);
+                const tbody = document.getElementById('scoreboard');
+                tbody.innerHTML = '';
+                data.forEach(row => {
+                    const tr = document.createElement('tr');
+                    tr.innerHTML = `<td>${row.user}</td><td>${row.points}</td>`;
+                    tbody.appendChild(tr);
+                });
+            };
+        },
+        handleAttempt(e) {
+            if (e.detail.requestConfig.path !== '/attempts') return;
+            const resp = JSON.parse(e.detail.xhr.responseText);
+            if (resp.correct) {
+                this.modal = `\u00a1Correcto! +${resp.gained_points} pts`;
+                this.disabled = [true, true, true, true];
+            } else {
+                this.modal = 'Incorrecto';
+                this.disabled[resp.option] = true;
+            }
+            document.getElementById('modal').style.display = 'block';
+        }
+    };
+}
+


### PR DESCRIPTION
## Summary
- add SQLite init script and sample data
- create FastAPI server with quiz endpoints and SSE scoreboard
- provide static front-end using HTMX and Alpine.js
- ignore generated files

## Testing
- `python init_db.py`
- `python -m uvicorn main:app --port 8000 --host 0.0.0.0 --workers 2 &`
- `curl -s http://localhost:8000/questions/1`
- `curl -s -X POST http://localhost:8000/attempts -H 'Content-Type: application/json' -d '{"user_id":1,"question_id":1,"option":0}'`
- `curl -s http://localhost:8000/events/group/1 --no-buffer --max-time 1`

------
https://chatgpt.com/codex/tasks/task_e_6874571ef0c48332bfaa28a6ec445e76