### PR TITLE
Improve quiz flow and SSE scoreboard

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -2,42 +2,42 @@
 <html lang="es" x-data="quizApp()" x-init="init()">
 <head>
     <meta charset="UTF-8">
-    <title>Quiz</title>
-    <script src="https://unpkg.com/htmx.org@1.9.6"></script>
-    <script src="https://unpkg.com/htmx.org@1.9.6/dist/ext/json-enc.js"></script>
+    <title>Juego de Preguntas</title>
+    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@1.*/css/pico.min.css">
     <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 </head>
 <body>
-    <div id="question">
+<main class="container">
+    <section id="question">
         <h2 x-text="question.text"></h2>
         <div>
             <template x-for="(opt, idx) in question.options" :key="idx">
-                <button
-                    :id="'btn'+idx"
-                    class="option"
-                    hx-post="/attempts"
-                    hx-ext="json-enc"
-                    :hx-vals="JSON.stringify({user_id: 1, question_id: question.id, option: idx})"
-                    hx-swap="none"
-                    @click.prevent="selected=idx"
-                    :disabled="disabled[idx]"
-                    x-text="opt">
-                </button>
+                <button @click="sendAttempt(idx)" :disabled="disabled[idx]" x-text="opt"></button>
             </template>
         </div>
-    </div>
+    </section>
 
-    <div id="modal" x-show="modal" style="display:none; border:1px solid #000; padding:1em;">
-        <span x-text="modal"></span>
-        <button @click="modal='';">Cerrar</button>
-    </div>
+    <dialog x-ref="feedback" :open="modalVisible">
+        <p x-text="modalText"></p>
+        <button @click="closeModal">Aceptar</button>
+    </dialog>
 
-    <h3>Scoreboard</h3>
+    <dialog x-ref="userDialog" :open="userModal">
+        <form @submit.prevent="saveUser">
+            <label>Nombre <input x-model="username" required></label>
+            <label>Grupo <input type="number" x-model.number="group" required></label>
+            <button type="submit">Empezar</button>
+        </form>
+    </dialog>
+
+    <h3>Puntajes</h3>
     <table>
         <thead><tr><th>Usuario</th><th>Puntos</th></tr></thead>
-        <tbody id="scoreboard"></tbody>
+        <tbody x-ref="scoreboard"></tbody>
     </table>
 
-    <script src="/static/js/app.js"></script>
+    <p x-show="finished">Juego terminado. Puntaje final: <span x-text="finalScore"></span></p>
+</main>
+<script src="/static/js/app.js"></script>
 </body>
 </html>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,41 +1,102 @@
 function quizApp() {
     return {
+        username: '',
+        group: '',
         question: {id: 1, text: '', options: []},
-        modal: '',
-        disabled: [false, false, false, false],
-        selected: null,
+        disabled: [],
+        modalVisible: false,
+        modalText: '',
+        userModal: false,
+        current: 1,
+        finished: false,
+        finalScore: 0,
+        scoreData: [],
         init() {
-            fetch('/questions/1')
-                .then(r => r.json())
-                .then(q => { this.question = q; });
+            this.username = localStorage.getItem('username');
+            this.group = localStorage.getItem('group');
+            if (!this.username || !this.group) {
+                this.userModal = true;
+            } else {
+                this.start();
+            }
+        },
+        saveUser() {
+            localStorage.setItem('username', this.username);
+            localStorage.setItem('group', this.group);
+            this.userModal = false;
+            this.start();
+        },
+        start() {
             this.connectSSE();
-            document.body.addEventListener('htmx:afterRequest', (e) => this.handleAttempt(e));
+            this.loadQuestion();
+        },
+        loadQuestion() {
+            fetch(`/questions/${this.current}`)
+                .then(r => {
+                    if (r.status === 404) {
+                        this.finished = true;
+                        this.finalScore = this.getMyPoints();
+                        this.modalText = 'Juego terminado';
+                        this.modalVisible = true;
+                        return null;
+                    }
+                    return r.json();
+                })
+                .then(q => {
+                    if (!q) return;
+                    this.question = q;
+                    this.disabled = new Array(q.options.length).fill(false);
+                });
+        },
+        sendAttempt(option) {
+            fetch('/attempts', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    user_name: this.username,
+                    group_id: parseInt(this.group),
+                    question_id: this.question.id,
+                    option: option
+                })
+            })
+                .then(r => r.json())
+                .then(resp => {
+                    if (resp.correct) {
+                        this.modalText = `\u2714 +${resp.gained_points} pts`;
+                        this.disabled = this.disabled.map(() => true);
+                        this.current += 1;
+                        this.loadQuestion();
+                    } else {
+                        this.modalText = '\u274C';
+                        this.disabled[option] = true;
+                        if (resp.attempts_left === 0) {
+                            this.current += 1;
+                            this.loadQuestion();
+                        }
+                    }
+                    this.modalVisible = true;
+                });
+        },
+        closeModal() {
+            this.modalVisible = false;
         },
         connectSSE() {
-            const evt = new EventSource('/events/group/1');
-            evt.onmessage = (ev) => {
+            const evt = new EventSource(`/events/group/${this.group}`);
+            evt.addEventListener('scoreboard', ev => {
                 const data = JSON.parse(ev.data);
-                const tbody = document.getElementById('scoreboard');
+                this.scoreData = data;
+                const tbody = this.$refs.scoreboard;
                 tbody.innerHTML = '';
                 data.forEach(row => {
                     const tr = document.createElement('tr');
                     tr.innerHTML = `<td>${row.user}</td><td>${row.points}</td>`;
                     tbody.appendChild(tr);
                 });
-            };
+            });
         },
-        handleAttempt(e) {
-            if (e.detail.requestConfig.path !== '/attempts') return;
-            const resp = JSON.parse(e.detail.xhr.responseText);
-            if (resp.correct) {
-                this.modal = `\u00a1Correcto! +${resp.gained_points} pts`;
-                this.disabled = [true, true, true, true];
-            } else {
-                this.modal = 'Incorrecto';
-                this.disabled[resp.option] = true;
-            }
-            document.getElementById('modal').style.display = 'block';
+        getMyPoints() {
+            const row = this.scoreData.find(r => r.user === this.username);
+            return row ? row.points : 0;
         }
     };
 }
-


### PR DESCRIPTION
## Summary
- prompt username and group, store in localStorage
- send attempts via fetch and advance questions
- update scoreboard via SSE with keep-alive pings
- display final score when questions end
- style page with Picocss

## Testing
- `python3 init_db.py`
- `pip install uvicorn sse-starlette fastapi`
- `python3 -m uvicorn main:app --port 8000 --timeout-keep-alive 1` *(fails: Module not found initially, installed packages then server started)*

------
https://chatgpt.com/codex/tasks/task_e_68746c28701c83329b3cf74ed4be32fc