### PR TITLE
Add admin panel and registration control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # juego
 Juego en equipo, resta puntos al responder erroneamente
+
+## Deployment
+
+```bash
+export ADMIN_PASSWORD="supersecret"
+uvicorn main:app --workers 2 --host 0.0.0.0 --port 8000
+```

--- a/init_db.py
+++ b/init_db.py
@@ -30,6 +30,8 @@ def main():
     conn = sqlite3.connect("quiz.db")
     c = conn.cursor()
 
+    c.execute('CREATE TABLE IF NOT EXISTS Settings (key TEXT PRIMARY KEY, value TEXT)')
+
     c.execute('CREATE TABLE IF NOT EXISTS "Group" (id INTEGER PRIMARY KEY, name TEXT)')
     c.execute('CREATE TABLE IF NOT EXISTS "User" (id INTEGER PRIMARY KEY, name TEXT, group_id INTEGER)')
     c.execute("""CREATE TABLE IF NOT EXISTS Question (
@@ -49,6 +51,7 @@ def main():
     c.executemany('INSERT INTO "Group"(id,name) VALUES (?,?)', GROUPS)
     c.executemany('INSERT INTO "User"(id,name,group_id) VALUES (?,?,?)', USERS)
     c.executemany("INSERT INTO Question(id,text,correct_option) VALUES (?,?,?)", QUESTIONS)
+    c.execute('INSERT OR IGNORE INTO Settings(key,value) VALUES ("registration_open","1")')
     conn.commit()
     conn.close()
     print("Base de datos inicializada")

--- a/static/admin.html
+++ b/static/admin.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es" x-data="adminApp()" x-init="init()">
+<head>
+    <meta charset="UTF-8">
+    <title>Panel Admin</title>
+    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@1.*/css/pico.min.css">
+    <script src="https://unpkg.com/htmx.org@1.9.2"></script>
+    <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+</head>
+<body>
+<main class="container">
+    <h2>Panel de Administraci&oacute;n</h2>
+    <button @click="toggleRegistration" x-text="registrationOpen ? 'Cerrar registro' : 'Abrir registro'"></button>
+    <p>Registro: <span x-text="registrationOpen ? 'abierto' : 'cerrado'"></span></p>
+    <p>Preguntas restantes: <span x-text="remaining"></span></p>
+    <label>Filtrar grupo
+        <select x-model="groupFilter">
+            <option value="">Todos</option>
+            <template x-for="g in groups" :key="g">
+                <option x-text="g" :value="g"></option>
+            </template>
+        </select>
+    </label>
+    <table>
+        <thead><tr><th>Grupo</th><th>Usuario</th><th>Puntos</th></tr></thead>
+        <tbody x-ref="scoreboard"></tbody>
+    </table>
+    <a href="/admin/export">Descargar CSV</a>
+</main>
+<script src="/static/js/admin.js"></script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -37,6 +37,7 @@
     </table>
 
     <p x-show="finished">Juego terminado. Puntaje final: <span x-text="finalScore"></span></p>
+    <p x-show="closed">💤 Juego en progreso, registro cerrado</p>
 </main>
 <script src="/static/js/app.js"></script>
 </body>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,0 +1,41 @@
+function adminApp() {
+    return {
+        registrationOpen: true,
+        remaining: 0,
+        groups: [],
+        groupFilter: '',
+        init() {
+            this.fetchStatus();
+            this.connectSSE();
+        },
+        fetchStatus() {
+            fetch('/admin/status')
+                .then(r => r.json())
+                .then(d => {
+                    this.registrationOpen = d.registration_open;
+                    this.remaining = d.remaining;
+                });
+        },
+        toggleRegistration() {
+            fetch('/admin/toggle-registration', {method: 'POST'})
+                .then(r => r.json())
+                .then(d => { this.registrationOpen = d.registration_open; });
+        },
+        connectSSE() {
+            const evt = new EventSource('/events/admin');
+            evt.addEventListener('scoreboard', ev => {
+                const data = JSON.parse(ev.data);
+                this.groups = [...new Set(data.map(r => r.group))];
+                const tbody = this.$refs.scoreboard;
+                tbody.innerHTML = '';
+                data.forEach(row => {
+                    if (this.groupFilter && parseInt(row.group) !== parseInt(this.groupFilter)) return;
+                    const tr = document.createElement('tr');
+                    tr.innerHTML = `<td>${row.group}</td><td>${row.user}</td><td>${row.points}</td>`;
+                    tbody.appendChild(tr);
+                });
+            });
+            evt.addEventListener('ping', () => {});
+        }
+    };
+}


### PR DESCRIPTION
## Summary
- set up DB Settings table with `registration_open`
- add admin basic auth and endpoints for managing registration
- broadcast global scoreboard to admin listeners via SSE
- handle registration closed state on frontend and backend
- create admin panel with scoreboard and export functionality
- send SSE keepalive pings every 25 seconds
- document deployment commands

## Testing
- `python -m py_compile main.py init_db.py`

------
https://chatgpt.com/codex/tasks/task_e_687597f970648332ae56e5c83534c672